### PR TITLE
Re-order the README to put the explanation first

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a very simple Ember 2.0 application that uses JSON Web Tokens (JWT) to authenticate to a protected API.
 
+To learn how this example was built, step by step, check out  [the doc directory](https://github.com/diegopoza/ember-jwt/tree/master/doc).
+
 ##Running it
 You must have ember-cli installed to make the solution work. You can install it by running:
 
@@ -27,6 +29,3 @@ ember serve.
 
 For the application to work properly, you must also get and run Auth0's  
 [NodeJS JWT Authentication sample](https://github.com/auth0/nodejs-jwt-authentication-sample), which will act as the JWT issuer and also provides the protected API we will call.
-
-##More information
-For more information about the sample, click [here](https://github.com/diegopoza/ember-jwt/tree/master/doc).


### PR DESCRIPTION
I started trying to dig through the actual application before I even realized there was a doc directory with explanations. It's a great explanation, it should be right up front!
